### PR TITLE
Adding functionality to announce a content description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rentalreviews",
       "version": "1.1.0",
       "dependencies": {
+        "@cacheable/node-cache": "^1.4.2",
         "@fortawesome/free-brands-svg-icons": "^6.5.2",
         "@fortawesome/free-regular-svg-icons": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -30,7 +31,6 @@
         "mongo": "^0.1.0",
         "mongodb": "^6.7.0",
         "next": "14.2.10",
-        "node-cache": "^5.1.2",
         "react-aria": "^3.35.1",
         "react-aria-components": "^1.3.3",
         "react-dom": "^18.2.0",
@@ -88,6 +88,26 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@cacheable/node-cache": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@cacheable/node-cache/-/node-cache-1.4.2.tgz",
+      "integrity": "sha512-S0nUwLUlJDyxUZJJSUuKIg3UkhYzeU0WCMFryH64M/ZbHAoUm2BcxGLpvQFtlMWghIFIphWXTG4wlV3F4PvwDg==",
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^1.8.1",
+        "eventemitter3": "^5.0.1",
+        "keyv": "^5.2.1"
+      }
+    },
+    "node_modules/@cacheable/node-cache/node_modules/keyv": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.2.1.tgz",
+      "integrity": "sha512-tpIgCaY02VCW2Pz0zAn4guyct+IeH6Mb5wZdOvpe4oqXeQOJO0C3Wo8fTnf7P3ZD83Vr9kghbkNmzG3lTOhy/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "*"
+      }
+    },
     "node_modules/@clack/core": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.3.4.tgz",
@@ -117,7 +137,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1058,6 +1077,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.1.tgz",
+      "integrity": "sha512-kKXeynfORDGPUEEl2PvTExM2zs+IldC6ZD8jPcfvI351MDNtfMlw9V9s4XZXuJNDK2qR5gbEKxRyoYx3quHUVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -8784,6 +8812,26 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -8853,6 +8901,30 @@
         "node": ">=16.20.1"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -8862,6 +8934,25 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.8.4.tgz",
+      "integrity": "sha512-eqcPwJIM8hcx2mQIZtgrBQ7BmOf2pkL+1URswJaKRikCDw5of/lGpBTxODL1z1VuVVuxZHTuTejAMd9vyAUpLg==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.5.0",
+        "keyv": "^5.2.1"
+      }
+    },
+    "node_modules/cacheable/node_modules/keyv": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.2.1.tgz",
+      "integrity": "sha512-tpIgCaY02VCW2Pz0zAn4guyct+IeH6Mb5wZdOvpe4oqXeQOJO0C3Wo8fTnf7P3ZD83Vr9kghbkNmzG3lTOhy/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "*"
       }
     },
     "node_modules/call-bind": {
@@ -9078,14 +9169,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/clsx": {
@@ -10075,6 +10158,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10678,6 +10767,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hookified": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.5.0.tgz",
+      "integrity": "sha512-4U0zw2ibOws7kfGdNCIL6oRg+t6ITxkgi9kUaJ71IDp0ZATHjvY6o7l90RBa/R8H2qOKl47SZISA5a3hNnei1g==",
+      "license": "MIT"
+    },
     "node_modules/html-dom-parser": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.8.tgz",
@@ -10734,6 +10829,26 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.1",
@@ -11952,17 +12067,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/node-cache": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
-      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
-      "dependencies": {
-        "clone": "2.x"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@cacheable/node-cache": "^1.4.2",
     "@fortawesome/free-brands-svg-icons": "^6.5.2",
     "@fortawesome/free-regular-svg-icons": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -31,7 +32,6 @@
     "mongo": "^0.1.0",
     "mongodb": "^6.7.0",
     "next": "14.2.10",
-    "node-cache": "^5.1.2",
     "react-aria": "^3.35.1",
     "react-aria-components": "^1.3.3",
     "react-dom": "^18.2.0",

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -8,12 +8,19 @@ import {Config, ConfigContext} from "@/lib/configProvider";
 
 import type { FaqQuestion } from "./faq-type";
 import type { Link as LinkType } from "@/lib/linktype";
+import {announce} from "@react-aria/live-announcer";
+import {notFound} from "next/navigation";
 
 export default async function FAQ() {
     const {faq}: Config = useContext(ConfigContext);
 
+    if(faq === undefined){
+        console.error("Data is undefined. Check DB connection.");
+        notFound();
+    }
+
   return (
-    <Article className="container">
+    <Article className="container" announcement={"Main content contains headings and text"}>
      <div className="flex flex-col text-center py-2">
      <h1 className="md:text-4xl">{faq.title}</h1>
      <h2 className="md:text-2xl no-underline font-normal">{faq.description}</h2>

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -19,7 +19,7 @@ export default function FAQ() {
     }
 
   return (
-    <Article className="container" announcement={"Main content contains a list of headings and text"}>
+    <Article className="container" announcement={faq.aria_announcement ?? undefined}>
      <div className="flex flex-col text-center py-2">
      <h1 className="md:text-4xl">{faq.title}</h1>
      <h2 className="md:text-2xl no-underline font-normal">{faq.description}</h2>

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -8,10 +8,9 @@ import {Config, ConfigContext} from "@/lib/configProvider";
 
 import type { FaqQuestion } from "./faq-type";
 import type { Link as LinkType } from "@/lib/linktype";
-import {announce} from "@react-aria/live-announcer";
 import {notFound} from "next/navigation";
 
-export default async function FAQ() {
+export default function FAQ() {
     const {faq}: Config = useContext(ConfigContext);
 
     if(faq === undefined){
@@ -20,7 +19,7 @@ export default async function FAQ() {
     }
 
   return (
-    <Article className="container" announcement={"Main content contains headings and text"}>
+    <Article className="container" announcement={"Main content contains a list of headings and text"}>
      <div className="flex flex-col text-center py-2">
      <h1 className="md:text-4xl">{faq.title}</h1>
      <h2 className="md:text-2xl no-underline font-normal">{faq.description}</h2>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,7 +58,7 @@ export default async function RootLayout({
         </header>
         <Config data={config}>
           <Suspense key={Math.random()} fallback={<Loading />}>
-            <main id="main-content" role="main" className={`${inter.variable}`}>
+            <main id="main-content" role="main" className={`${inter.variable}`} tabIndex={-1}>
               <Providers>{children}</Providers>
             </main>
           </Suspense>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,8 +9,6 @@ import Footer from "@/components/footer/footer";
 import "./globals.css";
 import Loading from "./loading";
 
-export const dynamic = "force-dynamic";
-
 import SkipToContent from "@/components/skip-to-content/skip";
 import { Alt } from "@/lib/configProvider";
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,7 +10,6 @@ import "./globals.css";
 import Loading from "./loading";
 
 import SkipToContent from "@/components/skip-to-content/skip";
-import { Alt } from "@/lib/configProvider";
 
 const inter = FontSans({
   subsets: ["latin"],

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,8 +1,9 @@
 "use client"
-import React from "react";
+import React, {useEffect} from "react";
 import Spinner from "@/components/spinner/spinner";
 
 
-export default function Loading(){    
+
+export default function Loading(){
     return <Spinner/>;
 }

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,8 +1,5 @@
-"use client"
-import React, {useEffect} from "react";
+import React from "react";
 import Spinner from "@/components/spinner/spinner";
-
-
 
 export default function Loading(){
     return <Spinner/>;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,33 +1,40 @@
 import Text from "@/components/text/text";
 import { notFound } from "next/navigation";
-import { getDocument } from "../db/db";
+import { getDocument } from "@/db/db";
 import type { Config, Text as TextType } from "@/lib/configProvider";
 import { Suspense } from "react";
-import {announce} from "@react-aria/live-announcer";
-
 
 import Loading from "./loading";
+import Article from "@/components/article/article";
 export default async function Home() {
-  
-  const {home}: Config | undefined = await getDocument<Config>("config", "config");
+  const { home }: Config | undefined = await getDocument<Config>(
+    "config",
+    "config",
+  );
 
-  if(home == undefined){
+  if (home == undefined) {
+    console.error("Data is undefined. Check DB connection.");
     notFound();
   }
 
   return (
     <div className="container mx-auto px-4">
-     <Suspense key={Math.random()} fallback={<Loading/>}>
-     <section className="my-20">
-        {home?.content?.map((elem: TextType, i: number) => (
-          <div key={i} role="article">
-            <h1 className="text-center md:text-4xl py-5">{elem.title}</h1>
-            <div className="md:px-15 py-10 border border-slate-400 rounded shadow-lg">
-              <Text text={elem.text} className="text-lg px-5 xs:text-base xl:text-xl indent-10" />
-            </div>
-          </div>
-        ))}
-      </section>
+      <Suspense key={Math.random()} fallback={<Loading />}>
+        <Article announcement={"Main content contains headings and paragraph text"}>
+          <section className="my-20">
+            {home?.content?.map((elem: TextType, i: number) => (
+              <div key={i} role="article">
+                <h1 className="text-center md:text-4xl py-5">{elem.title}</h1>
+                <div className="md:px-15 py-10 border border-slate-400 rounded shadow-lg">
+                  <Text
+                    text={elem.text}
+                    className="text-lg px-5 xs:text-base xl:text-xl indent-10"
+                  />
+                </div>
+              </div>
+            ))}
+          </section>
+        </Article>
       </Suspense>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,9 @@ import { notFound } from "next/navigation";
 import { getDocument } from "../db/db";
 import type { Config, Text as TextType } from "@/lib/configProvider";
 import { Suspense } from "react";
+import {announce} from "@react-aria/live-announcer";
+
+
 import Loading from "./loading";
 export default async function Home() {
   

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import { Suspense } from "react";
 import Loading from "./loading";
 import Article from "@/components/article/article";
 export default async function Home() {
-  const { home }: Config | undefined = await getDocument<Config>(
+  const { home }: Config = await getDocument<Config>(
     "config",
     "config",
   );
@@ -20,7 +20,7 @@ export default async function Home() {
   return (
     <div className="container mx-auto px-4">
       <Suspense key={Math.random()} fallback={<Loading />}>
-        <Article announcement={"Main content contains headings and paragraph text"}>
+        <Article announcement={home?.aria_announcement ?? undefined}>
           <section className="my-20">
             {home?.content?.map((elem: TextType, i: number) => (
               <div key={i} role="article">

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -8,7 +8,7 @@ import {notFound} from "next/navigation";
 
 import "./privacy_policy.css";
 
-export default async function PrivacyPolicy() {
+export default function PrivacyPolicy() {
   const { privacy_policy }: Config = useContext(ConfigContext);
 
   if(privacy_policy === undefined){

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -4,15 +4,21 @@ import {useContext} from "react";
 import Text from "@/components/text/text";
 import Article from "@/components/article/article";
 import {Config, ConfigContext} from "@/lib/configProvider";
+import {notFound} from "next/navigation";
 
 import "./privacy_policy.css";
 
-
 export default async function PrivacyPolicy() {
-  const { privacy_policy }: Config = useContext(ConfigContext)
+  const { privacy_policy }: Config = useContext(ConfigContext);
+
+  if(privacy_policy === undefined){
+      console.error("Data is undefined. Check DB connection.");
+      notFound();
+  }
+
 
   return (
-    <Article className="container">
+    <Article className="container" announcement={"Main content contains headings and text"}>
       <Text text={privacy_policy?.text ?? ""} />
     </Article>
   );

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -18,7 +18,7 @@ export default async function PrivacyPolicy() {
 
 
   return (
-    <Article className="container" announcement={"Main content contains headings and text"}>
+    <Article className="container" announcement={privacy_policy.aria_announcement ?? undefined}>
       <Text text={privacy_policy?.text ?? ""} />
     </Article>
   );

--- a/src/app/reviews/[slug]/data/json-wrapper.tsx
+++ b/src/app/reviews/[slug]/data/json-wrapper.tsx
@@ -1,6 +1,4 @@
-"use client"
 import { JsonViewer } from 'view-json-react';
-
 
 export function JsonWrapper({data}: Readonly<{
     data: { [key: string]: string }

--- a/src/app/reviews/[slug]/data/page.tsx
+++ b/src/app/reviews/[slug]/data/page.tsx
@@ -18,7 +18,7 @@ export default async function Data({params}: Readonly<{
 
   return (
     <div className="container mx-auto py-10">
-       <Article>
+       <Article announcement={"Main content contains collapsed elements and text in key-value pairs"}>
        <h1 className="text-center text-lg my-2">Raw Data for {companyData.name}</h1>
             <div className="rounded border border-slate-500 p-5 shadow-lg">
                 <JsonWrapper data={companyData}/>

--- a/src/app/reviews/[slug]/data/page.tsx
+++ b/src/app/reviews/[slug]/data/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { JsonWrapper } from "./json-wrapper";
 import Article from "@/components/article/article";
 
+export const dynamic = "force-dynamic";
 
 export default async function Data({params}: Readonly<{
     params: { [key: string]: string }

--- a/src/app/reviews/[slug]/page.tsx
+++ b/src/app/reviews/[slug]/page.tsx
@@ -7,6 +7,9 @@ import type { Company } from "../columns";
 
 import "./review.css";
 
+
+export const dynamic = "force-dynamic";
+
 export default async function Page({
   params,
 }: Readonly<{

--- a/src/app/reviews/[slug]/page.tsx
+++ b/src/app/reviews/[slug]/page.tsx
@@ -21,7 +21,7 @@ export default async function Page({
   const company: Company = await getCompanyData(slug);
 
   return (
-    <Article className="container mx-auto py-10 review-summary">
+    <Article className="container mx-auto py-10 review-summary" announcement={"Main content contains headings, a list containing text, and paragraph text"}>
       <Review data={company} />
     </Article>
   );

--- a/src/app/reviews/[slug]/review.tsx
+++ b/src/app/reviews/[slug]/review.tsx
@@ -6,16 +6,20 @@ import Link from "next/link";
 import Text from "@/components/text/text";
 import {Icon} from "@/components/icon/icon";
 import { Company } from "../columns";
+import {announce} from "@react-aria/live-announcer";
 import { Config, ConfigContext, getAltString } from "@/lib/configProvider";
 
 const adjustedReviewDisclaimerString = "Note: The Adjusted Review Count and Rating reflect only reviews with both text and a rating.";
-
 
 export function Review({ data }: Readonly<{ data: Company; }>) {
   // Note to self: this is to display the adjusted data, the disclaimer object is different. E.g. Son-Rise -> PURE
   const hasAdjustedReviewValue: boolean = data.review_count != data.adjusted_review_count;
   const { alt }: Config = useContext(ConfigContext)
-  const altObj: { [key: string]: string } = ["review_count", "average_rating", "adjusted_review_count", "adjusted_average_rating"].reduce((obj, curr) => ({ ...obj, [curr]: getAltString(alt, curr, data[curr]) }), {});
+  const altObj: { [key: string]: string } = ["review_count", "average_rating", "adjusted_review_count", "adjusted_average_rating"].reduce((obj, curr) => ({ ...obj, [curr]: getAltString(alt["review"], curr, data[curr]) }), {});
+
+  if(typeof window !== "undefined"){
+    announce("Main content contains headings, a list of text, and paragraph text.", "assertive", 500);
+  }
 
   return (
     <>

--- a/src/app/reviews/[slug]/review.tsx
+++ b/src/app/reviews/[slug]/review.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-
 import { useContext } from "react";
 import Link from "next/link";
 import Text from "@/components/text/text";
@@ -16,10 +15,6 @@ export function Review({ data }: Readonly<{ data: Company; }>) {
   const hasAdjustedReviewValue: boolean = data.review_count != data.adjusted_review_count;
   const { alt }: Config = useContext(ConfigContext)
   const altObj: { [key: string]: string } = ["review_count", "average_rating", "adjusted_review_count", "adjusted_average_rating"].reduce((obj, curr) => ({ ...obj, [curr]: getAltString(alt["review"], curr, data[curr]) }), {});
-
-  if(typeof window !== "undefined"){
-    announce("Main content contains headings, a list of text, and paragraph text.", "assertive", 500);
-  }
 
   return (
     <>

--- a/src/app/reviews/data-table.tsx
+++ b/src/app/reviews/data-table.tsx
@@ -270,13 +270,13 @@ export default function DataTable({
         {/* Mobile/Compact data view */}
         <ol
           className={
-            "visible md:hidden justify-center items-center px-10 space-y-3 py-5 bg-slate-200 border border-slate-500 rounded"
+            "visible md:hidden justify-center items-center px-10 space-y-2 py-5 bg-slate-200 border border-slate-500 rounded"
           }
         >
           {paginatedPageData.map((item: Company, i: number) => (
             <li
               key={i}
-              className={`flex flex-col text-start flex-1 bg-white border border-slate-800 rounded-lg p-5 my-1 shadow hover:shadow-xl hover:border-2 hover:border-black`}
+              className={`flex flex-col text-start flex-1 bg-white border border-slate-500 rounded-lg p-5 my-1 shadow hover:shadow-xl hover:border-black`}
               onMouseEnter={() => handleMouseEnter(item.slug)}
               onMouseLeave={() => handleMouseLeave(item.slug)}
             >

--- a/src/app/reviews/data-table.tsx
+++ b/src/app/reviews/data-table.tsx
@@ -276,7 +276,7 @@ export default function DataTable({
           {paginatedPageData.map((item: Company, i: number) => (
             <li
               key={i}
-              className={`flex flex-col text-start flex-1 bg-white border border-black rounded-lg p-5 my-1 shadow-lg`}
+              className={`flex flex-col text-start flex-1 bg-white border border-slate-800 rounded-lg p-5 my-1 shadow hover:shadow-xl hover:border-2 hover:border-black`}
               onMouseEnter={() => handleMouseEnter(item.slug)}
               onMouseLeave={() => handleMouseLeave(item.slug)}
             >
@@ -286,7 +286,14 @@ export default function DataTable({
                 aria-label={`Link to ${item.name} review page. Company Type ${item.company_type}. Average Rating ${item.average_rating} out of 5. Adjusted average rating ${item.adjusted_average_rating} out of 5. Review Count ${item.review_count}.`}
                 className={`text-start font-medium items-center justify-center hover:!no-underline`}
               >
-                <h2 className={"text-2xl underline"}>{item.name}</h2>
+                <h2 className={"text-2xl underline"}>
+                  <b>{item.name}</b>
+                  <Icon
+                      type="fas-link"
+                      className={`${hoverStates[item.slug] ? "visible" : "invisible"} m-1 h-5 w-5`}
+                  />
+                </h2>
+
                 <p>
                   <b>Company Type</b>: {item.company_type}
                 </p>

--- a/src/app/reviews/data-table.tsx
+++ b/src/app/reviews/data-table.tsx
@@ -150,7 +150,8 @@ export default function DataTable({
       )}
     >
       <div className={"sr-only"} aria-live="assertive" aria-atomic="true">
-        <p>{`Current layout ${isMobileWidth ? "list" : "table"}`}</p>
+        <p>Current layout</p>
+        {isMobileWidth ? <p>list</p> : <p>table</p>}
       </div>
       <div className="flex flex-col-reverse sm:flex-row flex-nowrap items-center gap-3 justify-end m-2">
         <div

--- a/src/app/reviews/data-table.tsx
+++ b/src/app/reviews/data-table.tsx
@@ -7,19 +7,26 @@ import {
   Row,
   Cell,
   Column,
-} from "../../components/aria-table/aria-table";
+} from "@/components/aria-table/aria-table";
 
 import { Icon } from "@/components/icon/icon";
 import { Input } from "@/components/ui/input";
-import { cn } from "../../lib/utils";
+import { cn } from "@/lib/utils";
 import { Company, ColumnType } from "@/app/reviews/columns";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { SortDescriptor } from "react-stately";
-import { Button } from "../../components/button/button";
+import { Button } from "@/components/button/button";
 import Link from "next/link";
 import { Select } from "@/components/select/select";
 
 const DEFAULT_PAGINATION_VALUE = 10;
+
+function getIsMobileWidth() {
+  if (typeof window !== "undefined") {
+    return window.innerWidth < 940;
+  }
+  return false;
+}
 export default function DataTable({
   columns,
   data,
@@ -33,6 +40,16 @@ export default function DataTable({
   className?: string;
   paginationValue?: number;
 }>) {
+  const [currentPageNumber, setCurrentPageNumberNumber] = useState(1);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [hoverStates, setHoverStates] = useState<{ [key: string]: boolean }>(
+    {},
+  );
+  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>({
+    column: "name",
+    direction: "ascending",
+  });
+  const [isMobileWidth, setIsMobileWidth] = useState(getIsMobileWidth());
   const colKeys = [
     "name",
     "company_type",
@@ -44,16 +61,6 @@ export default function DataTable({
     { key: "ascending", title: "Ascending" },
     { key: "descending", title: "Descending" },
   ];
-
-  const [currentPageNumber, setCurrentPageNumberNumber] = useState(1);
-  const [searchTerm, setSearchTerm] = useState("");
-  const [hoverStates, setHoverStates] = useState<{ [key: string]: boolean }>(
-    {},
-  );
-  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>({
-    column: "name",
-    direction: "ascending",
-  });
 
   // Filters data based on searchTerm
   const filteredData = useMemo(() => {
@@ -127,6 +134,14 @@ export default function DataTable({
     }));
   };
 
+  useEffect(() => {
+    function handleResize() {
+      setIsMobileWidth(getIsMobileWidth());
+    }
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   return (
     <div
       className={cn(
@@ -134,6 +149,9 @@ export default function DataTable({
         className,
       )}
     >
+      <div className={"sr-only"} aria-live="assertive" aria-atomic="true">
+        <p>{`Current layout ${isMobileWidth ? "list" : "table"}`}</p>
+      </div>
       <div className="flex flex-col-reverse sm:flex-row flex-nowrap items-center gap-3 justify-end m-2">
         <div
           className={
@@ -166,144 +184,148 @@ export default function DataTable({
             arialabel={"sort direction dropdown"}
           />
         </div>
-        <div className={`flex flex-row space-x-2 justify-center items-center`}>
+        <div
+          className={`flex flex-row space-x-2 justify-center items-center`}
+          tabIndex={-1}
+        >
           <label htmlFor="searchBox">Search</label>{" "}
           <Input
             id={"searchBox"}
             value={searchTerm}
+
             placeholder="Company Name"
             onChange={(e) => setSearchTerm(e.target.value)}
           />
         </div>
       </div>
-      <div
-          className="flex flex-col relative overflow-auto border-y-1 border-x-0.5 border-solid border-slate-500 rounded">
+      <div className="flex flex-col relative overflow-auto border-y-1 border-x-0.5 border-solid border-slate-500 rounded">
         {/* Full-screen data view */}
         <Table
-            aria-label={tableCaption}
-            sortDescriptor={sortDescriptor}
-            onSortChange={handleSortChange}
-            className="hidden md:table w-full"
+          aria-label={tableCaption}
+          sortDescriptor={sortDescriptor}
+          onSortChange={handleSortChange}
+          className="hidden md:table w-full"
         >
           <TableHeader>
             {columns.map((column, i: number) => (
-                <Column
-                    id={column.key}
-                    textValue={column.title}
-                    key={i}
-                    isRowHeader={i === 0}
-                    sortDescriptor={sortDescriptor}
-                    allowsSorting
-                    className={`border-black ${i < columns.length - 1 ? "border-r-1" : ""}`}
-                >
-                  <p>{column.title}</p>
-                </Column>
+              <Column
+                id={column.key}
+                textValue={column.title}
+                key={i}
+                isRowHeader={i === 0}
+                sortDescriptor={sortDescriptor}
+                allowsSorting
+                className={`border-black ${i < columns.length - 1 ? "border-r-1" : ""}`}
+              >
+                <p>{column.title}</p>
+              </Column>
             ))}
           </TableHeader>
           <TableBody>
             {paginatedPageData.map((item: Company, i: number) => (
-                <Row key={i}>
-                  {colKeys.map((key: string, j: number) => (
-                      <Cell
-                          key={j}
-                          className={`${j < colKeys.length - 1 ? "border-black border-r-1" : ""}`}
+              <Row key={i}>
+                {colKeys.map((key: string, j: number) => (
+                  <Cell
+                    key={j}
+                    className={`${j < colKeys.length - 1 ? "border-black border-r-1" : ""}`}
+                  >
+                    {j == 0 ? (
+                      <Link
+                        id={`${item.slug}`}
+                        href={`/reviews/${item.slug}`}
+                        aria-label={`Link to ${item[key]}`}
+                        className={`flex mx-3 font-medium items-center justify-center`}
+                        onMouseEnter={() => handleMouseEnter(item.slug)}
+                        onMouseLeave={() => handleMouseLeave(item.slug)}
                       >
-                        {j == 0 ? (
-                            <Link
-                                id={`${item.slug}`}
-                                href={`/reviews/${item.slug}`}
-                                aria-label={`Link to ${item[key]}`}
-                                className={`flex mx-3 font-medium items-center justify-center`}
-                                onMouseEnter={() => handleMouseEnter(item.slug)}
-                                onMouseLeave={() => handleMouseLeave(item.slug)}
-                            >
-                              <p className="px-2">{`${item[key]}`}</p>
-                              <Icon
-                                  type="fas-link"
-                                  className={`${hoverStates[item.slug] ? "visible" : "invisible"} mx-1 h-4 w-4`}
-                              />
-                            </Link>
-                        ) : (
-                            <p>{`${item[key]}${key.includes("rating") ? "/5" : ""}`}</p>
-                        )}
-                      </Cell>
-                  ))}
-                </Row>
+                        <p className="px-2">{`${item[key]}`}</p>
+                        <Icon
+                          type="fas-link"
+                          className={`${hoverStates[item.slug] ? "visible" : "invisible"} mx-1 h-4 w-4`}
+                        />
+                      </Link>
+                    ) : (
+                      <p>{`${item[key]}${key.includes("rating") ? "/5" : ""}`}</p>
+                    )}
+                  </Cell>
+                ))}
+              </Row>
             ))}
           </TableBody>
         </Table>
 
         {/* Mobile/Compact data view */}
         <ol
-            className={
-              "visible md:hidden justify-center items-center px-10 space-y-3 py-5 bg-slate-200 border border-slate-500 rounded"
-            }
+          className={
+            "visible md:hidden justify-center items-center px-10 space-y-3 py-5 bg-slate-200 border border-slate-500 rounded"
+          }
         >
           {paginatedPageData.map((item: Company, i: number) => (
-              <li
-                  key={i}
-                  className={`flex flex-col text-start flex-1 bg-white border border-black rounded-lg p-5 my-1 shadow-lg`}
-                  onMouseEnter={() => handleMouseEnter(item.slug)}
-                  onMouseLeave={() => handleMouseLeave(item.slug)}
+            <li
+              key={i}
+              className={`flex flex-col text-start flex-1 bg-white border border-black rounded-lg p-5 my-1 shadow-lg`}
+              onMouseEnter={() => handleMouseEnter(item.slug)}
+              onMouseLeave={() => handleMouseLeave(item.slug)}
+            >
+              <Link
+                id={`${item.slug}`}
+                href={`/reviews/${item.slug}`}
+                aria-label={`Link to ${item.name} review page. Company Type ${item.company_type}. Average Rating ${item.average_rating} out of 5. Adjusted average rating ${item.adjusted_average_rating} out of 5. Review Count ${item.review_count}.`}
+                className={`text-start font-medium items-center justify-center hover:!no-underline`}
               >
-                <Link
-                    id={`${item.slug}`}
-                    href={`/reviews/${item.slug}`}
-                    aria-label={`Link to ${item.name} review page. Company Type ${item.company_type}. Average Rating ${item.average_rating} out of 5. Adjusted average rating ${item.adjusted_average_rating} out of 5. Review Count ${item.review_count}.`}
-                    className={`text-start font-medium items-center justify-center hover:!no-underline`}
-                >
-                  <h2 className={"text-2xl underline"}>{item.name}</h2>
-                  <p>
-                    <b>Company Type</b>: {item.company_type}
-                  </p>
-                  <p>
-                    <b>Average Rating</b>: {item.average_rating}/5
-                  </p>
-                  <p>
-                    <b>Adjusted Average Rating</b>: {item.adjusted_average_rating}/5
-                  </p>
-                  <p>
-                    <b>Review Count</b>: {item.review_count}
-                  </p>
-                </Link>
-              </li>
+                <h2 className={"text-2xl underline"}>{item.name}</h2>
+                <p>
+                  <b>Company Type</b>: {item.company_type}
+                </p>
+                <p>
+                  <b>Average Rating</b>: {item.average_rating}/5
+                </p>
+                <p>
+                  <b>Adjusted Average Rating</b>: {item.adjusted_average_rating}
+                  /5
+                </p>
+                <p>
+                  <b>Review Count</b>: {item.review_count}
+                </p>
+              </Link>
+            </li>
           ))}
         </ol>
         <span className="py-2 flex flex-col justify-center text-center">
           <span className="flex flex-row justify-center text-center space-x-1">
             <Button
-                variant={"ghost"}
-                aria-label="last page"
-                disabled={currentPageNumber === 1}
-                aria-disabled={currentPageNumber === 1}
-                onClick={() => handlePageChange(1)}
+              variant={"ghost"}
+              aria-label="last page"
+              disabled={currentPageNumber === 1}
+              aria-disabled={currentPageNumber === 1}
+              onClick={() => handlePageChange(1)}
             >
               {"<<"}
             </Button>
             <Button
-                variant={"ghost"}
-                aria-label="previous page"
-                disabled={currentPageNumber === 1}
-                aria-disabled={currentPageNumber === 1}
-                onClick={() => handlePageChange(currentPageNumber - 1)}
+              variant={"ghost"}
+              aria-label="previous page"
+              disabled={currentPageNumber === 1}
+              aria-disabled={currentPageNumber === 1}
+              onClick={() => handlePageChange(currentPageNumber - 1)}
             >
               {"<"}
             </Button>
             <Button
-                variant={"ghost"}
-                aria-label="next page"
-                disabled={currentPageNumber === pageCount}
-                aria-disabled={currentPageNumber === pageCount}
-                onClick={() => handlePageChange(currentPageNumber + 1)}
+              variant={"ghost"}
+              aria-label="next page"
+              disabled={currentPageNumber === pageCount}
+              aria-disabled={currentPageNumber === pageCount}
+              onClick={() => handlePageChange(currentPageNumber + 1)}
             >
               {">"}
             </Button>
             <Button
-                variant={"ghost"}
-                aria-label="last page"
-                disabled={currentPageNumber === pageCount}
-                aria-disabled={currentPageNumber === pageCount}
-                onClick={() => handlePageChange(pageCount)}
+              variant={"ghost"}
+              aria-label="last page"
+              disabled={currentPageNumber === pageCount}
+              aria-disabled={currentPageNumber === pageCount}
+              onClick={() => handlePageChange(pageCount)}
             >
               {">>"}
             </Button>

--- a/src/app/reviews/data-table.tsx
+++ b/src/app/reviews/data-table.tsx
@@ -18,12 +18,13 @@ import { SortDescriptor } from "react-stately";
 import { Button } from "@/components/button/button";
 import Link from "next/link";
 import { Select } from "@/components/select/select";
+import {announce} from "@react-aria/live-announcer";
 
 const DEFAULT_PAGINATION_VALUE = 10;
 
 function getIsMobileWidth() {
   if (typeof window !== "undefined") {
-    return window.innerWidth < 940;
+    return window.innerWidth <= 940;
   }
   return false;
 }
@@ -61,6 +62,7 @@ export default function DataTable({
     { key: "ascending", title: "Ascending" },
     { key: "descending", title: "Descending" },
   ];
+  let hasMadeAnnouncement = false;
 
   // Filters data based on searchTerm
   const filteredData = useMemo(() => {
@@ -134,10 +136,24 @@ export default function DataTable({
     }));
   };
 
+
   useEffect(() => {
-    function handleResize() {
-      setIsMobileWidth(getIsMobileWidth());
+    function announceHandler(){
+      if(isMobileWidth){
+        announce("Main content contains a heading and a list of links", "assertive", 500);
+      } else {
+        announce("Main content contains a heading and a data table", "assertive", 500);
+      }
     }
+    function handleResize() {
+      const isWindowMobileWidth = getIsMobileWidth();
+      if(isWindowMobileWidth != isMobileWidth){
+        setIsMobileWidth(isWindowMobileWidth);
+        announceHandler();
+      }
+    }
+    // To make the layout announcement on first load
+    announceHandler();
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, []);
@@ -149,10 +165,6 @@ export default function DataTable({
         className,
       )}
     >
-      <div className={"sr-only"} aria-live="assertive" aria-atomic="true">
-        <p>Current layout</p>
-        {isMobileWidth ? <p>list</p> : <p>table</p>}
-      </div>
       <div className="flex flex-col-reverse sm:flex-row flex-nowrap items-center gap-3 justify-end m-2">
         <div
           className={

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -4,6 +4,8 @@ import DataTable from "@/app/reviews/data-table";
 import Article from "@/components/article/article";
 import {notFound} from "next/navigation";
 
+export const dynamic = "force-dynamic";
+
 export default async function Reviews() {
   const reviewData: Company | undefined = await getDocument<Company>("index", "properties_and_companies_index");
   const tableCaption = "Rental Reviews Data";

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -2,6 +2,7 @@ import { Company } from "./columns";
 import { getDocument } from "@/db/db";
 import DataTable from "@/app/reviews/data-table";
 import Article from "@/components/article/article";
+import {notFound} from "next/navigation";
 
 export default async function Reviews() {
   const reviewData: Company | undefined = await getDocument<Company>("index", "properties_and_companies_index");
@@ -30,8 +31,13 @@ export default async function Reviews() {
         },
     ];
 
+    if(reviewData === undefined){
+        console.error("Data is undefined. Check DB connection.");
+        notFound();
+    }
+
   return (
-    <Article className="flex flex-col justify-center text-center container mx-auto py-10">
+    <Article className="flex flex-col justify-center text-center container mx-auto py-10" announcement={"Main content contains headings and text"}>
         <h1 className=" md:text-4xl my-4">{tableCaption}</h1>
         <DataTable data={reviewData.data} columns={ColumnKeys} tableCaption={tableCaption}/>
     </Article>

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -37,7 +37,7 @@ export default async function Reviews() {
     }
 
   return (
-    <Article className="flex flex-col justify-center text-center container mx-auto py-10" announcement={"Main content contains headings and text"}>
+    <Article className="flex flex-col justify-center text-center container mx-auto py-10">
         <h1 className=" md:text-4xl my-4">{tableCaption}</h1>
         <DataTable data={reviewData.data} columns={ColumnKeys} tableCaption={tableCaption}/>
     </Article>

--- a/src/components/article/article.tsx
+++ b/src/components/article/article.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { announce } from "@react-aria/live-announcer";
+import React from "react";
 
 export default function Article({
   children,

--- a/src/components/article/article.tsx
+++ b/src/components/article/article.tsx
@@ -1,13 +1,23 @@
+"use client";
 
+import { announce } from "@react-aria/live-announcer";
 
-export default function Article({children, className = '', ...props}: Readonly<{
-    children: React.ReactNode;
-    className?: string;
-    [key: string]: any;
-}>){
-    return (
-        <article className={`flex flex-col ${className}`} {...props}>
-            {children}
-        </article>
-    )
+export default function Article({
+  children,
+  className = "",
+  ...props
+}: Readonly<{
+  children: React.ReactNode;
+  className?: string;
+  [key: string]: any;
+}>) {
+  if (props.announcement && typeof window !== "undefined") {
+    announce(props.announcement, "assertive", 500);
+  }
+
+  return (
+    <article className={`flex flex-col ${className}`} {...props}>
+      {children}
+    </article>
+  );
 }

--- a/src/components/skip-to-content/skip.tsx
+++ b/src/components/skip-to-content/skip.tsx
@@ -9,13 +9,19 @@ export default function SkipToContent({
   className?: string;
   [key: string]: any | any[];
 }>) {
+
   return (
     <Link
     id="skip-link"
     href={props.url}
     className={`transition left-0 bg-primary text-primary-content absolute p-3 m-3 -translate-y-16 focus:translate-y-0 ${className}`}
     onClick={e => {
-      e.currentTarget.blur();
+      e.preventDefault();
+      e.currentTarget?.blur();
+      const container: HTMLElement | null = document.querySelector(props.url);
+      if(container){
+        container.focus();
+      }
     }}
     {...props}
     >

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -21,7 +21,7 @@ export async function getCollection<T extends TProps<T>>(collection: string, TTL
   collection = collection.trim();
 
   if (collection_arr === undefined) {
-    if (DB_ENV == DB_ENVS.LOCAL) {
+    if (process.env.NEXT_PUBLIC_DB_ENV === "local") {
       collection_arr = (await mongoGetCollection<T[]>(collection)) ?? undefined;
     } else {
       collection_arr = (await firestoreGetCollection<T[]>({ collection_name: collection } as RequestType)) ?? undefined;
@@ -37,7 +37,7 @@ export async function getDocument<T extends TProps<T>>(collection: string, docum
   document_id = document_id.trim();
 
   if (document === undefined) {
-      if (DB_ENV == DB_ENVS.LOCAL) {
+      if (process.env.NEXT_PUBLIC_DB_ENV === "local") {
         document = await mongoGetDocument<T>(collection, document_id);
       } else {
         document = await firestoreGetDocument<T>({ collection_name: collection, query_props: { id: document_id } } as RequestType)

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -1,9 +1,15 @@
 import { firestoreGetCollection, firestoreGetDocument } from "./firebase";
 import { mongoGetCollection, mongoGetDocument } from "./mongo";
-import { development as isDevelopment } from "@/lib/configProvider";
 import type { RequestType } from "./requesttype";
 
 const CACHE_TTL: number = process.env.NEXT_PUBLIC_CACHE_TTL ? parseInt(process.env.NEXT_PUBLIC_CACHE_TTL) || 3600000 : 3600000; // 1 month if .env value isn't there.
+export const DB_ENV = process.env.NEXT_PUBLIC_DB_ENV ?? "local";
+
+export enum DB_ENVS {
+  LOCAL = "local",
+  TEST = "test",
+  PRODUCTION = "production"
+}
 
 type TProps<T> = {
   [k: string]: string | number | T | T[keyof T];
@@ -15,7 +21,7 @@ export async function getCollection<T extends TProps<T>>(collection: string, TTL
   collection = collection.trim();
 
   if (collection_arr === undefined) {
-    if (isDevelopment) {
+    if (DB_ENV == DB_ENVS.LOCAL) {
       collection_arr = (await mongoGetCollection<T[]>(collection)) ?? undefined;
     } else {
       collection_arr = (await firestoreGetCollection<T[]>({ collection_name: collection } as RequestType)) ?? undefined;
@@ -29,9 +35,9 @@ export async function getDocument<T extends TProps<T>>(collection: string, docum
   let document: T | undefined = global.documentCache?.get(`${collection}/${document_id}`) ?? undefined;
   collection = collection.trim();
   document_id = document_id.trim();
-  
+
   if (document === undefined) {
-      if (isDevelopment) {
+      if (DB_ENV == DB_ENVS.LOCAL) {
         document = await mongoGetDocument<T>(collection, document_id);
       } else {
         document = await firestoreGetDocument<T>({ collection_name: collection, query_props: { id: document_id } } as RequestType)

--- a/src/db/firebase.ts
+++ b/src/db/firebase.ts
@@ -12,7 +12,17 @@ import type { FirebaseApp } from "firebase/app";
 import type { RequestType } from "./requesttype";
 
 const firebaseConfig = () => {
-  const configObj = {
+  if(process.env.NEXT_PUBLIC_DB_ENV === "test"){
+    return {
+      apiKey: process.env.NEXT_PUBLIC_FIREBASE_STAGING_API_KEY,
+      authDomain: process.env.NEXT_PUBLIC_FIREBASE_STAGING_AUTH_DOMAIN,
+      projectId: process.env.NEXT_PUBLIC_FIREBASE_STAGING_PROJECT_ID,
+      storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STAGING_STORAGE_BUCKET,
+      messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_STAGING_MESSAGING_SENDER_ID,
+      appId: process.env.NEXT_PUBLIC_FIREBASE_STAGING_APP_ID,
+    };
+  }
+  return {
     apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
     authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
     projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
@@ -20,7 +30,6 @@ const firebaseConfig = () => {
     messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
     appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
   };
-  return configObj;
 }
 
 const app: FirebaseApp = initializeApp(firebaseConfig());
@@ -52,7 +61,7 @@ export const firestoreGetDocument = async <T>(props: RequestType) => {
     }
     return docSnapshot.data() as T;
   } catch (error) {
-    console.error("Error geting data:", error); 
+    console.error("Error getting data:", error);
 
     return undefined;
   }

--- a/src/db/mongo.ts
+++ b/src/db/mongo.ts
@@ -17,7 +17,7 @@ export const mongoGetCollection = async <T>(collection: string) => {
   } catch (err) {
     console.error("Error getting data: ", err);
   } finally {
-    client.close();
+    await client.close();
   }
 };
 
@@ -32,6 +32,6 @@ export const mongoGetDocument = async <T>(collection: string, document_id: strin
   } catch (err) {
     console.error("Error getting data: ", err);
   } finally {
-    client.close();
+    await client.close();
   }
 };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,4 +1,4 @@
-import type NodeCache from 'node-cache';
+import type NodeCache from '@cacheable/node-cache';
 
 declare global {
   var collectionCache: NodeCache;

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,9 +1,10 @@
-import type NodeCache from 'node-cache';
+// import type NodeCache from 'node-cache';
+import {NodeCacheOptions} from "@cacheable/node-cache";
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const NodeCache = (await import('node-cache')).default;
-    const config: NodeCache.Options = {
+    const NodeCache = (await import('@cacheable/node-cache')).default;
+    const config: NodeCacheOptions = {
       stdTTL: process.env.NODE_ENV === 'production' ? 0 : 60,
     };
 

--- a/src/lib/configProvider.tsx
+++ b/src/lib/configProvider.tsx
@@ -5,6 +5,7 @@ import React, { createContext } from "react";
 export type Config = {
   [key: string]: {
     name: string;
+    aria_announcement?:string;
     title?: string;
     description?: string;
     text?: Text[];

--- a/src/lib/configProvider.tsx
+++ b/src/lib/configProvider.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext } from "react";
+import React, { createContext } from "react";
 
 export type Config = {
   [key: string]: {

--- a/src/lib/configProvider.tsx
+++ b/src/lib/configProvider.tsx
@@ -38,9 +38,6 @@ export function getAltString(altObj: AltRecord, key: string, value: any) {
   return "undefined";
 }
 
-
-export const development: boolean = !process.env.NODE_ENV || process.env.NODE_ENV === 'development';
-
 export const ConfigContext = createContext({});
 
 export function Config({ data, children }: Readonly<{

--- a/src/lib/getCompanyData.ts
+++ b/src/lib/getCompanyData.ts
@@ -1,4 +1,4 @@
-import { getDocument, getCollection, DB_ENV, DB_ENVS } from "@/db/db";
+import { getDocument, getCollection} from "@/db/db";
 import { Company } from "@/app/reviews/columns";
 
 export default async function getCompanyData(slug: string): Promise<Company> {
@@ -8,11 +8,11 @@ export default async function getCompanyData(slug: string): Promise<Company> {
   const [company, review] = await Promise.all([companyPromise, reviewPromise]);
 
   if (company) {
-    delete company[DB_ENV == DB_ENVS.LOCAL ? "_id" : "id"];
+    delete company[process.env.NEXT_PUBLIC_DB_ENV === "local"? "_id" : "id"];
   }
 
   if (review) {
-    delete review[DB_ENV == DB_ENVS.LOCAL  ? "_id" : "id"];
+    delete review[process.env.NEXT_PUBLIC_DB_ENV === "local" ? "_id" : "id"];
   }
 
   return {

--- a/src/lib/getCompanyData.ts
+++ b/src/lib/getCompanyData.ts
@@ -1,6 +1,5 @@
-import { getDocument, getCollection } from "@/db/db";
+import { getDocument, getCollection, DB_ENV, DB_ENVS } from "@/db/db";
 import { Company } from "@/app/reviews/columns";
-import { development } from "./configProvider";
 
 export default async function getCompanyData(slug: string): Promise<Company> {
   const companyPromise: Promise<Company> = getDocument<Company>("properties_and_companies", slug);
@@ -9,11 +8,11 @@ export default async function getCompanyData(slug: string): Promise<Company> {
   const [company, review] = await Promise.all([companyPromise, reviewPromise]);
 
   if (company) {
-    delete company[development ? "_id" : "id"];
+    delete company[DB_ENV == DB_ENVS.LOCAL ? "_id" : "id"];
   }
 
   if (review) {
-    delete review[development ? "_id" : "id"];
+    delete review[DB_ENV == DB_ENVS.LOCAL  ? "_id" : "id"];
   }
 
   return {


### PR DESCRIPTION
Adding functionality to announce the page content type to users with screen readers. 

ADDITIONALLY I'm adding some tweaks to the DB file such that it respects the .env variable `NEXT_PUBLIC_DB_ENV` to dictate which database it looks at. `test` will point to `rentalreviews-test`, `production` will point to `rentalreviews`. 